### PR TITLE
Adapt to nic/packet_allocator 2-byte aligned packets

### DIFF
--- a/src/drivers/nic/cadence_gem/buffer_descriptor.h
+++ b/src/drivers/nic/cadence_gem/buffer_descriptor.h
@@ -30,7 +30,6 @@ class Cadence_gem::Buffer_descriptor : protected Attached_ram_dataspace, protect
 {
 	public:
 		static const size_t BUFFER_DESC_SIZE = 0x08;
-		static const size_t BUFFER_SIZE      = 1600;
 
 	private:
 		size_t _buffer_count;

--- a/src/drivers/nic/cadence_gem/rx_buffer_descriptor.h
+++ b/src/drivers/nic/cadence_gem/rx_buffer_descriptor.h
@@ -30,6 +30,8 @@ class Cadence_gem::Rx_buffer_descriptor : public Buffer_descriptor
 {
 	private:
 
+		static const size_t BUFFER_SIZE = Nic::Packet_allocator::OFFSET_PACKET_SIZE;
+
 		struct Addr : Register<0x00, 32> {
 			struct Addr31to2 : Bitfield<2, 30> {};
 			struct Wrap : Bitfield<1, 1> {};

--- a/src/drivers/nic/cadence_gem/tx_buffer_descriptor.h
+++ b/src/drivers/nic/cadence_gem/tx_buffer_descriptor.h
@@ -36,6 +36,8 @@ class Cadence_gem::Tx_buffer_descriptor : public Buffer_descriptor
 	private:
 		enum { BUFFER_COUNT = 1024 };
 
+		static const size_t BUFFER_SIZE = Nic::Packet_allocator::OFFSET_PACKET_SIZE;
+
 		struct Addr : Register<0x00, 32> {};
 		struct Status : Register<0x04, 32> {
 			struct Length  : Bitfield<0, 14> {};


### PR DESCRIPTION
Fixes the following error.

  [init -> drivers -> zynq_nic_drv] Error: unsupported NIC packet size 1600

Issue genodelabs/genode#4312